### PR TITLE
feat(auth): implement secure refresh token system using HttpOnly cookies

### DIFF
--- a/src/main/java/com/example/bookapi/constants/CookieConstants.java
+++ b/src/main/java/com/example/bookapi/constants/CookieConstants.java
@@ -1,0 +1,7 @@
+package com.example.bookapi.constants;
+
+public class CookieConstants {
+    public static final String REFRESH_TOKEN = "refreshToken";
+    public static final String REFRESH_PATH = "/";
+    public static final int REFRESH_MAX_AGE = 7 * 24 * 60 * 60;
+}

--- a/src/main/java/com/example/bookapi/controller/AuthController.java
+++ b/src/main/java/com/example/bookapi/controller/AuthController.java
@@ -1,19 +1,23 @@
 package com.example.bookapi.controller;
 
+import com.example.bookapi.constants.CookieConstants;
 import com.example.bookapi.constants.SuccessMessages;
 import com.example.bookapi.dto.LoginRequest;
 import com.example.bookapi.dto.RefreshTokenRequest;
 import com.example.bookapi.dto.RegisterRequest;
 import com.example.bookapi.dto.AuthResponse;
-import com.example.bookapi.service.AuthService;
-import com.example.bookapi.service.JwtService;
-import com.example.bookapi.service.RefreshTokenService;
-import com.example.bookapi.service.TokenBlacklistService;
+import com.example.bookapi.service.*;
+import com.example.bookapi.util.CookieUtils;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Date;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -24,6 +28,7 @@ public class AuthController {
     private final RefreshTokenService refreshTokenService;
     private final TokenBlacklistService tokenBlacklistService;
     private final JwtService jwtService;
+    private final TokenCookieService tokenCookieService;
 
     @PostMapping("/register")
     public AuthResponse register(@RequestBody RegisterRequest request) {
@@ -31,22 +36,54 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public AuthResponse login(@RequestBody LoginRequest request) {
-        return authService.login(request);
+    public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest request, HttpServletResponse response) {
+        AuthResponse authResponse = authService.login(request);
+
+        Cookie refreshCookie = tokenCookieService.createRefreshTokenCookie(authResponse.getRefreshToken());
+        response.addCookie(refreshCookie);
+
+        AuthResponse responseWithoutRefresh = new AuthResponse(authResponse.getAccessToken(), null);
+        return ResponseEntity.ok(responseWithoutRefresh);
     }
 
     @PostMapping("/refresh-token")
-    public AuthResponse refreshToken(@RequestBody RefreshTokenRequest request) {
-        return authService.refreshToken(request.getRefreshToken());
+    public ResponseEntity<AuthResponse> refreshToken(HttpServletRequest request) {
+        Optional<Cookie> refreshCookie = CookieUtils.getCookie(request, CookieConstants.REFRESH_TOKEN);
+
+        if(refreshCookie.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String refreshToken = refreshCookie.get().getValue();
+        AuthResponse response = authService.refreshToken(refreshToken);
+
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/logout")
     public ResponseEntity<?> logoutUser(@RequestHeader("Authorization") String authHeader,
-                                        @RequestBody RefreshTokenRequest request) {
+                                        @RequestBody RefreshTokenRequest request,
+                                        HttpServletResponse response) {
+
         refreshTokenService.deleteByToken(request.getRefreshToken());
         String token = authHeader.replace("Bearer ", "").trim();
         Date expirationDate = jwtService.extractExpiration(token);
         tokenBlacklistService.blacklistToken(token, expirationDate.toInstant());
+
+        tokenCookieService.clearRefreshTokenCookie(response);
+
         return ResponseEntity.ok(SuccessMessages.LOGOUT_SUCCESS);
+    }
+
+    @GetMapping("/refresh-token-cookie")
+    public ResponseEntity<AuthResponse> refreshTokenFromCookie(
+            @CookieValue(name ="refreshToken", required = false) String refreshToken
+    ) {
+        if(refreshToken == null || refreshToken.isEmpty()) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        AuthResponse authResponse = authService.refreshToken(refreshToken);
+        return ResponseEntity.ok(authResponse);
     }
 }

--- a/src/main/java/com/example/bookapi/dto/AuthResponse.java
+++ b/src/main/java/com/example/bookapi/dto/AuthResponse.java
@@ -1,10 +1,12 @@
 package com.example.bookapi.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AuthResponse {
     private String accessToken;
     private String refreshToken;

--- a/src/main/java/com/example/bookapi/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/bookapi/security/JwtAuthenticationFilter.java
@@ -55,6 +55,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if(tokenBlacklistService.isTokenBlacklisted(jwt)) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.getWriter().write(ErrorMessages.TOKEN_REVOKED);
+            return;
         }
 
         userName = jwtService.extractUsername(jwt);

--- a/src/main/java/com/example/bookapi/service/TokenCookieService.java
+++ b/src/main/java/com/example/bookapi/service/TokenCookieService.java
@@ -1,0 +1,28 @@
+package com.example.bookapi.service;
+
+import com.example.bookapi.constants.CookieConstants;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TokenCookieService {
+
+    public Cookie createRefreshTokenCookie(String token) {
+        Cookie cookie = new Cookie(CookieConstants.REFRESH_TOKEN, token);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath(CookieConstants.REFRESH_PATH);
+        cookie.setMaxAge(CookieConstants.REFRESH_MAX_AGE);
+        return cookie;
+    }
+
+    public void clearRefreshTokenCookie(HttpServletResponse response) {
+        Cookie refreshCookie = new Cookie(CookieConstants.REFRESH_TOKEN, null);
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setSecure(true);
+        refreshCookie.setPath(CookieConstants.REFRESH_PATH);
+        refreshCookie.setMaxAge(0);
+        response.addCookie(refreshCookie);
+    }
+}

--- a/src/main/java/com/example/bookapi/util/CookieUtils.java
+++ b/src/main/java/com/example/bookapi/util/CookieUtils.java
@@ -1,0 +1,18 @@
+package com.example.bookapi.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public class CookieUtils {
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        if(request.getCookies() == null) return Optional.empty();
+
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> name.equals(cookie.getName()))
+                .findFirst();
+    }
+}


### PR DESCRIPTION
- Set refresh token as HttpOnly, Secure cookie on login
- Created TokenCookieService to handle cookie operations
- Added refresh-token-cookie endpoint to renew access tokens using cookie
- Updated logout to clear refresh cookie and blacklist access token